### PR TITLE
Use console.error to log thrown error stack trace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules
 logs
 *.log
 npm-debug.log*
-
+# IDEs
+/.idea/

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const compile = function (module, filename) {
       plugins: ['transform-es2015-modules-commonjs']
     }).code, bubleOpts).code, filename)
   } catch (err) {
-    console.trace(err)
+    console.error(err.stack)
   }
 }
 


### PR DESCRIPTION
Use `console.error` to log the stack trace of the thrown error.  `console.trace` will [always log a stack trace that points at the line where `console.trace` is called](https://nodejs.org/api/console.html#console_console_trace_message), rather than the stack trace of an error passed to it.
