### PR TITLE
fix(register): errors should be thrown so tests fail properly

### DIFF
--- a/register.js
+++ b/register.js
@@ -20,13 +20,9 @@ const shouldSkip = file => contains(file, 'node_modules')
 const original = require.extensions['.js']
 
 const compile = function (module, filename) {
-  try {
-    module._compile(transform(transformFileSync(filename, {
-      plugins: [babelPlugin]
-    }).code, bubleOpts).code, filename)
-  } catch (err) {
-    console.error(err.stack)
-  }
+  module._compile(transform(transformFileSync(filename, {
+    plugins: [babelPlugin]
+  }).code, bubleOpts).code, filename)
 }
 
 const compileEachExtension = ext => require.extensions[ext] = (module, filename) => shouldSkip(filename) ? original(module, filename) : compile(module, filename) // eslint-disable-line no-return-assign


### PR DESCRIPTION
When a file fails to be transformed, it should throw and error to ensure
that tests do not pass when they should not.

Closes #17 
